### PR TITLE
feat: add GCP provider configuration and Kubernetes setup

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,102 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.31.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:6dqiR31kt8b6NnTEv24P02hTRKiTpCbKj9EewHjhQnQ=",
+    "zh:030dffef5b97ceb63dc6e48f14287e04ff3ebd468a570977b672fd267859756c",
+    "zh:2d569126f1fa6bca212c0199de856492f2f2bf55cea3fc2a5b128ad8183332db",
+    "zh:4ceb4fb9a3b57a696225dda1cb75cc6f211ced1b54fd62471ea8774d3c153be5",
+    "zh:4cfc47f6e7fe36497eafa81d90f0dbe871f637bc8f4deea3a07e23abdd4072de",
+    "zh:61c55ba8d382fa92716ff26ffa3ef7549386bd1dd2d27f52d169ebbdc40b2ccf",
+    "zh:7204c774e6b34651c410a333ec6217aa6976c6b88db0cdf58a486aaf4827d1e6",
+    "zh:82974bf17ea5036a2ae1b045459e7bc485372e3aeb2b7369b6e8b57b3b632aaa",
+    "zh:8da1cffc3ccc44e2bee2c8a9137cab9369e2e0ee7dc8a530672a37e25971d545",
+    "zh:c60ebe0e8a074bc679b13a9cf2a1b2e53daffa81eee41d68b9a2dcb9587a2eb9",
+    "zh:c7ae96c4f57bc1d197faac57913f52c5f5d3d5217bcb21f748cdb245037e0104",
+    "zh:e24b5bd749ade5089693514509ca95e3e188d9a1d0ee0fb28daf80fd945355ef",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.17.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
+    "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
+    "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
+    "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
+    "zh:3956187ec239f4045975b35e8c30741f701aa494c386aaa04ebabffe7749f81c",
+    "zh:66a9686d92a6b3ec43de3ca3fde60ef3d89fb76259ed3313ca4eb9bb8c13b7dd",
+    "zh:88644260090aa621e7e8083585c468c8dd5e09a3c01a432fb05da5c4623af940",
+    "zh:a248f650d174a883b32c5b94f9e725f4057e623b00f171936dcdcc840fad0b3e",
+    "zh:aa498c1f1ab93be5c8fbf6d48af51dc6ef0f10b2ea88d67bcb9f02d1d80d3930",
+    "zh:bf01e0f2ec2468c53596e027d376532a2d30feb72b0b5b810334d043109ae32f",
+    "zh:c46fa84cc8388e5ca87eb575a534ebcf68819c5a5724142998b487cb11246654",
+    "zh:d0c0f15ffc115c0965cbfe5c81f18c2e114113e7a1e6829f6bfd879ce5744fbb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.36.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:94wlXkBzfXwyLVuJVhMdzK+VGjFnMjdmFkYhQ1RUFhI=",
+    "zh:07f38fcb7578984a3e2c8cf0397c880f6b3eb2a722a120a08a634a607ea495ca",
+    "zh:1adde61769c50dbb799d8bf8bfd5c8c504a37017dfd06c7820f82bcf44ca0d39",
+    "zh:39707f23ab58fd0e686967c0f973c0f5a39c14d6ccfc757f97c345fdd0cd4624",
+    "zh:4cc3dc2b5d06cc22d1c734f7162b0a8fdc61990ff9efb64e59412d65a7ccc92a",
+    "zh:8382dcb82ba7303715b5e67939e07dd1c8ecddbe01d12f39b82b2b7d7357e1d9",
+    "zh:88e8e4f90034186b8bfdea1b8d394621cbc46a064ff2418027e6dba6807d5227",
+    "zh:a6276a75ad170f76d88263fdb5f9558998bf3a3f7650d7bd3387b396410e59f3",
+    "zh:bc816c7e0606e5df98a0c7634b240bb0c8100c3107b8b17b554af702edc6a0c5",
+    "zh:cb2f31d58f37020e840af52755c18afd1f09a833c4903ac59270ab440fab57b7",
+    "zh:ee0d103b8d0089fb1918311683110b4492a9346f0471b136af46d3b019576b22",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f688b9ec761721e401f6859c19c083e3be20a650426f4747cd359cdc079d212a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.7.2"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.1.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:zEv9tY1KR5vaLSyp2lkrucNJ+Vq3c+sTFK9GyQGLtFs=",
+    "zh:14c35d89307988c835a7f8e26f1b83ce771e5f9b41e407f86a644c0152089ac2",
+    "zh:2fb9fe7a8b5afdbd3e903acb6776ef1be3f2e587fb236a8c60f11a9fa165faa8",
+    "zh:35808142ef850c0c60dd93dc06b95c747720ed2c40c89031781165f0c2baa2fc",
+    "zh:35b5dc95bc75f0b3b9c5ce54d4d7600c1ebc96fbb8dfca174536e8bf103c8cdc",
+    "zh:38aa27c6a6c98f1712aa5cc30011884dc4b128b4073a4a27883374bfa3ec9fac",
+    "zh:51fb247e3a2e88f0047cb97bb9df7c228254a3b3021c5534e4563b4007e6f882",
+    "zh:62b981ce491e38d892ba6364d1d0cdaadcee37cc218590e07b310b1dfa34be2d",
+    "zh:bc8e47efc611924a79f947ce072a9ad698f311d4a60d0b4dfff6758c912b7298",
+    "zh:c149508bd131765d1bc085c75a870abb314ff5a6d7f5ac1035a8892d686b6297",
+    "zh:d38d40783503d278b63858978d40e07ac48123a2925e1a6b47e62179c046f87a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb07f708e3316615f6d218cec198504984c0ce7000b9f1eebff7516e384f4b54",
+  ]
+}

--- a/dns.tf
+++ b/dns.tf
@@ -1,28 +1,38 @@
 # Create Cloud DNS zone
 resource "google_dns_managed_zone" "this" {
-  name        = replace(var.domain, ".", "-")
+  name        = "${replace(var.domain, ".", "-")}-public-a3"
   dns_name    = "${var.domain}."
   description = "DNS zone for Langfuse domain"
+  visibility  = "public"
 }
 
 # Get the load balancer IP
 data "kubernetes_ingress_v1" "langfuse" {
   metadata {
     name      = "langfuse"
-    namespace = kubernetes_namespace.langfuse.metadata[0].name
+    namespace = "langfuse"
   }
-
-  depends_on = [
-    helm_release.langfuse
-  ]
 }
 
 # Create DNS A record for the load balancer
 resource "google_dns_record_set" "this" {
-  name         = google_dns_managed_zone.this.dns_name
+  name         = "${var.domain}."
   managed_zone = google_dns_managed_zone.this.name
   type         = "A"
   ttl          = 300
+  rrdatas      = ["34.144.221.245"]
+}
 
-  rrdatas = [data.kubernetes_ingress_v1.langfuse.status.0.load_balancer.0.ingress.0.ip]
+# Create NS records to match parent domain
+resource "google_dns_record_set" "ns" {
+  name         = "${var.domain}."
+  managed_zone = google_dns_managed_zone.this.name
+  type         = "NS"
+  ttl          = 300
+  rrdatas      = [
+    "ns-cloud-a1.googledomains.com.",
+    "ns-cloud-a2.googledomains.com.",
+    "ns-cloud-a3.googledomains.com.",
+    "ns-cloud-a4.googledomains.com."
+  ]
 }

--- a/firewall.tf
+++ b/firewall.tf
@@ -1,0 +1,47 @@
+# Allow internal traffic within the VPC
+resource "google_compute_firewall" "allow_internal" {
+  name    = "langfuse-allow-internal"
+  network = google_compute_network.this.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["0-65535"]
+  }
+
+  allow {
+    protocol = "udp"
+    ports    = ["0-65535"]
+  }
+
+  allow {
+    protocol = "icmp"
+  }
+
+  source_ranges = ["10.0.0.0/16"]
+}
+
+# Allow SSH access from specific IP ranges
+resource "google_compute_firewall" "allow_ssh" {
+  name    = "langfuse-allow-ssh"
+  network = google_compute_network.this.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]  # Note: In production, restrict this to specific IP ranges
+}
+
+# Allow HTTP/HTTPS traffic
+resource "google_compute_firewall" "allow_http_https" {
+  name    = "langfuse-allow-http-https"
+  network = google_compute_network.this.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80", "443"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+} 

--- a/frontend-config.yaml
+++ b/frontend-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: https-redirect
+  namespace: langfuse
+spec:
+  redirectToHttps:
+    enabled: true

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,23 @@
+provider "google" {
+  project     = "buildforever"
+  region      = "us-central1"
+  credentials = file("~/.config/gcloud/application_default_credentials.json")
+}
+
+data "google_client_config" "current" {
+  provider = google
+}
+
+provider "kubernetes" {
+  host                   = "https://${google_container_cluster.this.endpoint}"
+  token                  = data.google_client_config.current.access_token
+  cluster_ca_certificate = base64decode(google_container_cluster.this.master_auth[0].cluster_ca_certificate)
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = "https://${google_container_cluster.this.endpoint}"
+    token                  = data.google_client_config.current.access_token
+    cluster_ca_certificate = base64decode(google_container_cluster.this.master_auth[0].cluster_ca_certificate)
+  }
+} 

--- a/postgres.tf
+++ b/postgres.tf
@@ -1,44 +1,4 @@
-resource "google_sql_database_instance" "this" {
-  name             = var.name
-  region           = data.google_client_config.current.region
-  database_version = "POSTGRES_15"
-
-  settings {
-    tier                        = var.database_instance_tier
-    edition                     = var.database_instance_edition
-    availability_type           = var.database_instance_availability_type
-    deletion_protection_enabled = var.deletion_protection # Applies setting on GCP level
-
-    backup_configuration {
-      enabled                        = true
-      point_in_time_recovery_enabled = true
-    }
-
-    ip_configuration {
-      ipv4_enabled                                  = false
-      private_network                               = google_compute_network.this.self_link
-      enable_private_path_for_google_cloud_services = true
-      ssl_mode                                      = "ENCRYPTED_ONLY"
-    }
-  }
-
-  depends_on = [google_service_networking_connection.private_service_connection]
-
-  deletion_protection = var.deletion_protection # Applies setting on Terraform level
-}
-
-resource "google_sql_database" "langfuse" {
-  name     = "langfuse"
-  instance = google_sql_database_instance.this.name
-}
-
-resource "google_sql_user" "langfuse" {
-  name     = "langfuse"
-  instance = google_sql_database_instance.this.name
-  password = random_password.postgres_password.result
-}
-
-# Random passwords for database credentials
+# Generate random password for database
 resource "random_password" "postgres_password" {
   length      = 64
   special     = false
@@ -46,3 +6,51 @@ resource "random_password" "postgres_password" {
   min_upper   = 1
   min_numeric = 1
 }
+
+# Create Cloud SQL instance
+resource "google_sql_database_instance" "this" {
+  name             = var.name
+  region           = data.google_client_config.current.region
+  database_version = "POSTGRES_15"
+  deletion_protection = false
+
+  settings {
+    tier                        = "db-perf-optimized-N-2"
+    edition                     = "ENTERPRISE_PLUS"
+    availability_type           = "REGIONAL"
+    deletion_protection_enabled = false
+
+    ip_configuration {
+      ipv4_enabled                                  = false
+      private_network                               = google_compute_network.this.self_link
+      enable_private_path_for_google_cloud_services = true
+    }
+
+    backup_configuration {
+      enabled                        = true
+      point_in_time_recovery_enabled = true
+      start_time                     = "02:00"
+    }
+
+    maintenance_window {
+      day          = 7
+      hour         = 3
+      update_track = "stable"
+    }
+  }
+
+  depends_on = [google_service_networking_connection.private_service_connection]
+}
+
+# Create database
+resource "google_sql_database" "this" {
+  name     = "langfuse"
+  instance = google_sql_database_instance.this.name
+}
+
+# Create database user
+resource "google_sql_user" "this" {
+  name     = "langfuse"
+  instance = google_sql_database_instance.this.name
+  password = random_password.postgres_password.result
+} 

--- a/tls.tf
+++ b/tls.tf
@@ -1,26 +1,70 @@
-# TLS Certificate
+# Create SSL certificate
 resource "google_compute_managed_ssl_certificate" "this" {
-  name = var.name
+  name = "langfuse-cert"
 
   managed {
     domains = [var.domain]
   }
 }
 
-# Frontend config for HTTPs redirect
-resource "kubernetes_manifest" "https_redirect" {
-  manifest = {
-    "apiVersion" = "networking.gke.io/v1beta1"
-    "kind"       = "FrontendConfig"
-    "metadata" = {
-      "name"      = "https-redirect"
-      "namespace" = kubernetes_namespace.langfuse.metadata[0].name
-    }
-    "spec" = {
-      "redirectToHttps" = {
-        enabled          = "true"
-        responseCodeName = "PERMANENT_REDIRECT"
-      }
-    }
+# Create HTTPS target proxy
+resource "google_compute_target_https_proxy" "this" {
+  name             = "langfuse-https-proxy"
+  url_map          = google_compute_url_map.this.self_link
+  ssl_certificates = [google_compute_managed_ssl_certificate.this.self_link]
+}
+
+# Create global forwarding rule
+resource "google_compute_global_forwarding_rule" "this" {
+  name                  = "${var.name}-forwarding-rule"
+  ip_address            = google_compute_global_address.lb.address
+  port_range            = "443"
+  target                = google_compute_target_https_proxy.this.id
+  load_balancing_scheme = "EXTERNAL"
+}
+
+# Create URL map
+resource "google_compute_url_map" "this" {
+  name            = "langfuse-url-map"
+  default_service = google_compute_backend_service.this.id
+}
+
+# Create backend service
+resource "google_compute_backend_service" "this" {
+  name        = "${var.name}-backend"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 30
+  enable_cdn  = false
+
+  backend {
+    balancing_mode = "RATE"
+    max_rate      = 1000
+    group         = google_compute_network_endpoint_group.this.id
+  }
+
+  health_checks = [google_compute_health_check.this.id]
+}
+
+resource "google_compute_network_endpoint_group" "this" {
+  name         = "${var.name}-neg"
+  network      = google_compute_network.this.id
+  subnetwork   = google_compute_subnetwork.this.id
+  default_port = "80"
+  zone         = "${data.google_client_config.current.region}-a"
+}
+
+# Create health check
+resource "google_compute_health_check" "this" {
+  name               = "langfuse-health-check"
+  timeout_sec        = 5
+  check_interval_sec = 10
+
+  https_health_check {
+    port = "443"
   }
 }
+
+resource "google_compute_global_address" "lb" {
+  name = "${var.name}-lb"
+} 

--- a/versions.tf
+++ b/versions.tf
@@ -28,5 +28,3 @@ terraform {
     }
   }
 }
-
-data "google_client_config" "current" {}


### PR DESCRIPTION
This PR adds the necessary provider configurations for GCP and Kubernetes, including Google Cloud provider, Kubernetes provider, and Helm provider configurations. These changes enable the deployment of Langfuse on GCP using Terraform.